### PR TITLE
cli: exit with proper status code

### DIFF
--- a/src/speclj/cli.clj
+++ b/src/speclj/cli.clj
@@ -105,4 +105,4 @@
       (or (:speclj config) (:help config)) (usage nil)
       :else (or (do-specs config) 0))))
 
-(def -main run)
+(def -main (comp System/exit (partial min 255) Math/abs run))


### PR DESCRIPTION
Why do this?

Utilities invoked at the shell are expected to. clj-kondo and cljfmt
check do, for example. So does the cognitect test-runner.  The really
good reason to is for tools like make, which stop after encountering the
first non-ignore error. Plus, it enables CI builds to indicate a failed
status correctly.

On the implementation

For reasons I cannot fathom, -1 has been chosen as the special "error"
status, so I just keep the absolute value.  Thankfully, 0 is already
considered success. I also clamp to 255 as the maximum value, for
safety.

I stuck with the existing style of not wrapping functions in `(fn [] ,,,)`
when not necessary, preferring `(comp)` and `(partial)`.